### PR TITLE
Initialize job board structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,23 @@
-# React + TypeScript + Vite
+# BizTalent Hub
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project is a job board application built with **Vite**, **React** and **TypeScript**. It provides a starting point for building a platform where businesses can post jobs, search and manage candidates, and handle payments.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Multi‑step wizard for creating job postings
+- Candidate search and management interface
+- Stripe payment integration
+- WhatsApp or Email contact links for candidates
 
-## Expanding the ESLint configuration
+## Development
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+Install dependencies and start the development server:
 
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The application is served at `http://localhost:5173` by default.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
-
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+This repo was bootstrapped from the standard Vite + React template and extended with an initial project structure to support the features above.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,23 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import Navbar from './components/Navbar'
+import Home from './pages/Home'
+import JobWizard from './features/jobWizard/JobWizard'
+import CandidateManagement from './features/candidates/CandidateManagement'
+import StripeCheckout from './features/payments/StripeCheckout'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
+    <BrowserRouter>
+      <Navbar />
+      <div style={{ padding: '1rem' }}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/post-job" element={<JobWizard />} />
+          <Route path="/candidates" element={<CandidateManagement />} />
+          <Route path="/payment" element={<StripeCheckout />} />
+        </Routes>
       </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    </BrowserRouter>
   )
 }
-
-export default App

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom'
+
+export default function Navbar() {
+  return (
+    <nav style={{ padding: '1rem', borderBottom: '1px solid #ccc' }}>
+      <Link to="/" style={{ marginRight: '1rem' }}>Home</Link>
+      <Link to="/post-job" style={{ marginRight: '1rem' }}>Post Job</Link>
+      <Link to="/candidates" style={{ marginRight: '1rem' }}>Candidates</Link>
+      <Link to="/payment" style={{ marginRight: '1rem' }}>Payment</Link>
+    </nav>
+  )
+}

--- a/src/features/candidates/CandidateContact.tsx
+++ b/src/features/candidates/CandidateContact.tsx
@@ -1,0 +1,12 @@
+export default function CandidateContact() {
+  return (
+    <div>
+      <h3>Contact Candidate</h3>
+      <p>
+        Reach out via 
+        <a href="https://www.whatsapp.com" target="_blank" rel="noreferrer">WhatsApp</a> 
+        or <a href="mailto:someone@example.com">Email</a>.
+      </p>
+    </div>
+  )
+}

--- a/src/features/candidates/CandidateManagement.tsx
+++ b/src/features/candidates/CandidateManagement.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react'
+
+export default function CandidateManagement() {
+  const [search, setSearch] = useState('')
+
+  return (
+    <div>
+      <h2>Candidate Search &amp; Management</h2>
+      <input
+        placeholder="Search candidates"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+      />
+      {/* Candidate list would be rendered here based on search */}
+      <p style={{ marginTop: '1rem' }}>
+        Searching for: <strong>{search}</strong>
+      </p>
+    </div>
+  )
+}

--- a/src/features/jobWizard/JobWizard.tsx
+++ b/src/features/jobWizard/JobWizard.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+const steps = ['Job Details', 'Requirements', 'Review']
+
+export default function JobWizard() {
+  const [step, setStep] = useState(0)
+
+  function next() {
+    setStep((s) => Math.min(s + 1, steps.length - 1))
+  }
+
+  function prev() {
+    setStep((s) => Math.max(s - 1, 0))
+  }
+
+  return (
+    <div>
+      <h2>Create Job Posting</h2>
+      <p>Step {step + 1}: {steps[step]}</p>
+      {/* Form fields for each step would go here */}
+      <div style={{ marginTop: '1rem' }}>
+        <button onClick={prev} disabled={step === 0}>Back</button>
+        {step < steps.length - 1 ? (
+          <button onClick={next}>Next</button>
+        ) : (
+          <button onClick={() => alert('Submit job')}>Submit</button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/payments/StripeCheckout.tsx
+++ b/src/features/payments/StripeCheckout.tsx
@@ -1,0 +1,16 @@
+import { loadStripe } from '@stripe/stripe-js'
+import { Elements } from '@stripe/react-stripe-js'
+
+const stripePromise = loadStripe('pk_test_YOUR_KEY_HERE')
+
+export default function StripeCheckout() {
+  return (
+    <div>
+      <h2>Stripe Payment</h2>
+      <Elements stripe={stripePromise}>
+        {/* Add your checkout form here */}
+        <p>Checkout form goes here.</p>
+      </Elements>
+    </div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h2>Welcome to BizTalent Hub</h2>
+      <p>Your platform for hiring the best talent.</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- set up base features for a job board app
- add pages for home, job wizard, candidate management, and Stripe checkout
- provide a simple navigation bar
- update README with how to run the app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687c3c96826c832db94fbe228efe2069